### PR TITLE
Do not define TrueLabel type

### DIFF
--- a/ml/ml_table.yaml
+++ b/ml/ml_table.yaml
@@ -1,12 +1,5 @@
 # hdmf-schema-language=2.0.2
 datasets:
-- data_type_def: TrueLabel
-  data_type_inc: VectorData
-  doc: A column to store the true labels for each sample. To store labels as strings, use EnumData.
-    The training_labels attribute on other columns in the ResultsTable should reference this column
-    if present.
-  dtype: int
-
 - data_type_def: SupervisedOutput
   data_type_inc: VectorData
   doc: A column to store supervised learning output
@@ -96,7 +89,11 @@ groups:
     doc: A column to indicate which cross-validation fold a sample was part of
     quantity: '?'
   - name: true_label
-    data_type_inc: TrueLabel
+    data_type_inc: VectorData
+    doc: A column to store the true labels for each sample. To store labels as strings, use EnumData.
+      The training_labels attribute on other columns in the ResultsTable should reference this column
+      if present.
+    dtype: int
     doc: A column to store the true label for each sample
     quantity: '?'
   - name: predicted_proba

--- a/ml/ml_table.yaml
+++ b/ml/ml_table.yaml
@@ -9,7 +9,7 @@ datasets:
       reftype: object
       target_type: VectorData
     required: false
-    doc: The training labels that were used. Reference the TrueLabel column if present
+    doc: The training labels that were used. Reference the true_label column if present
       in the same ResultsTable.
 
 - data_type_def: TrainValidationTestSplit
@@ -63,7 +63,7 @@ datasets:
       reftype: object
       target_type: VectorData
     required: false
-    doc: The training labels that were used. Reference the TrueLabel column if present
+    doc: The training labels that were used. Reference the true_label column if present
       in the same ResultsTable.
 
 - data_type_def: EmbeddedValues

--- a/ml/ml_table.yaml
+++ b/ml/ml_table.yaml
@@ -93,8 +93,6 @@ groups:
     doc: A column to store the true labels for each sample. To store labels as strings, use EnumData.
       The training_labels attribute on other columns in the ResultsTable should reference this column
       if present.
-    dtype: int
-    doc: A column to store the true label for each sample
     quantity: '?'
   - name: predicted_proba
     data_type_inc: ClassProbability


### PR DESCRIPTION
If we define a `data_type_def: TrueLabel` that has `data_type_inc: VectorData`, then you cannot actually use an `EnumData` to represent the true labels. There is no need to define another data type, so instead of the above approach, define a column in `ResultsTable` with 
```yaml
name: true_label
data_type_inc: VectorData
doc: ...
dtype: int
```